### PR TITLE
Update main.js for use gpt-4o-mini

### DIFF
--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ function requestVision(image_url, { lang } = {}) {
     });
   }
   return openai.chat.completions.create({
-    model: 'gpt-4o-mini',
+    model: 'gpt-4o-2024-08-06',
     messages,
     max_tokens: MAX_TOKENS,
   });

--- a/main.js
+++ b/main.js
@@ -41,7 +41,7 @@ function requestVision(image_url, { lang } = {}) {
     });
   }
   return openai.chat.completions.create({
-    model: 'gpt-4o',
+    model: 'gpt-4o-mini',
     messages,
     max_tokens: MAX_TOKENS,
   });


### PR DESCRIPTION
I'm testing the alt text creation with the gpt-4o-mini model and it works pretty well. The gpt-4o-mini model has a lower cost compared to the gpt-4o model.